### PR TITLE
enhance internal network security phrasing

### DIFF
--- a/data/pages/docs/getting-started.yml
+++ b/data/pages/docs/getting-started.yml
@@ -148,8 +148,8 @@ the overall Cloud Foundry installation.
 ### Internal Network
 
 Most of the managerial parts of Cloud Foundry exist in the _internal_
-network.  These are components that need to talk to one another, but do not
-need to be access by application containers, or the outside world, directly.
+network.  These are components that need to talk to one another, but should not
+be accessible to application containers, or the outside world, directly.
 
 <table class="listing">
   <thead><tr>


### PR DESCRIPTION
* emphasize best practice with "should" in place of "need"
* fix "be access" grammar mistake
  * if "should" is acceptabled, I suggest "be accessible"
  * if "need" is better to be retained, one should use "be accessible to" or "be accessed by"
